### PR TITLE
Fix build problem on Mac which doesn't have librt

### DIFF
--- a/scikits/umfpack/setup.py
+++ b/scikits/umfpack/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # 05.12.2005, c
 from __future__ import division, print_function, absolute_import
+import sys
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
@@ -14,7 +15,8 @@ def configuration(parent_package='',top_path=None):
     ## The following addition is needed when linking against a umfpack built
     ## from the latest SparseSuite. Not (strictly) needed when linking against
     ## the version in the ubuntu repositories.
-    umf_info['libraries'].insert(0, 'rt')
+    if not sys.platform == 'darwin':
+        umf_info['libraries'].insert(0, 'rt')
 
     umfpack_i_file = config.paths('umfpack.i')[0]
 


### PR DESCRIPTION
Add handling for building scikit-umfpack on the Mac, which doesn't have the librt file added to the umfpack dependencies.

The fix is just a simple test if we are on darwin, and if so skipping the add of the librt.