### PR TITLE
Long indices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ language: python
 sudo: false
 matrix:
   include:
-    - python: 2.6
     - python: 2.7
       env: DOCS=1
     - python: 3.4
+    - python: 3.5
+    - python: 3.6
 addons:
   apt:
     packages:
@@ -25,7 +26,7 @@ before_install:
   - travis_retry pip install --upgrade pip wheel   # get pip >= 7, which caches built packages
   - travis_retry pip install numpy
   # Convert pip output to dots so that Travis doesn't quit while scipy is building
-  - (pip install -v scipy==0.16.0 2>&1 | tee scipy-build.log | perl -e 'my $start=time(); local $|=1; while (<STDIN>) { if (time() > $start + 5) { print "."; $start=time(); }; }') || { cat scipy-build.log; exit 1; }
+  - (pip install -v scipy 2>&1 | tee scipy-build.log | perl -e 'my $start=time(); local $|=1; while (<STDIN>) { if (time() > $start + 5) { print "."; $start=time(); }; }') || { cat scipy-build.log; exit 1; }
   - |
     if [ "$DOCS" == "1" ]; then
         travis_retry pip install Sphinx numpydoc

--- a/scikits/umfpack/interface.py
+++ b/scikits/umfpack/interface.py
@@ -188,8 +188,8 @@ class UmfpackLU(object):
         if A.dtype.char not in 'dD':
             raise ValueError("Only double precision matrices supported")
 
-        family = {'d': 'di', 'D': 'zi'}
-        self.umf = UmfpackContext(family[A.dtype.char])
+        family = {'di': 'di', 'Di': 'zi', 'dl': 'dl', 'Dl': 'zl'}
+        self.umf = UmfpackContext(family[A.dtype.char + A.indices.dtype.char])
         self.umf.numeric(A)
 
         self._A = A

--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -95,3 +95,6 @@ class TestSolvers(object):
         A2 = (R * Pr.T * (lu.L * lu.U) * Pc.T).A
 
         assert_allclose(A2, A.A, atol=1e-13)
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -1,19 +1,20 @@
 from __future__ import division, print_function, absolute_import
 
 import warnings
-import random
 
-from numpy.testing import assert_allclose, run_module_suite
+from numpy.testing import assert_allclose, run_module_suite, dec
 from numpy.testing.utils import WarningManager
 from numpy.linalg import norm as dense_norm
 
-from scipy import rand, matrix, diag, eye
 from scipy.sparse import csc_matrix, spdiags, SparseEfficiencyWarning
 from scipy.sparse import hstack
-from scipy.sparse.linalg import linsolve
 
 import numpy as np
 import scikits.umfpack as um
+
+
+_is_32bit_platform = np.intp(0).itemsize < 8
+
 
 # Force int64 index dtype even when indices fit into int32.
 def _to_int64(x):
@@ -21,6 +22,7 @@ def _to_int64(x):
     y.indptr = y.indptr.astype(np.int64)
     y.indices = y.indices.astype(np.int64)
     return y
+
 
 class TestSolvers(object):
     """Tests inverting a sparse linear system"""
@@ -46,10 +48,10 @@ class TestSolvers(object):
         x = um.spsolve(a, b)
         assert_allclose(a*x, b)
 
-    def test_solve_complex_long_umfpack(self):
-        # Solve with UMFPACK: double precision complex, long indices
+    @dec.skipif(_is_32bit_platform)
+    def test_solve_complex_int64_umfpack(self):
+        # Solve with UMFPACK: double precision complex, int64 indices
         a = _to_int64(self.a.astype('D'))
-
         b = self.b
         x = um.spsolve(a, b)
         assert_allclose(a*x, b)
@@ -61,8 +63,9 @@ class TestSolvers(object):
         x = um.spsolve(a, b)
         assert_allclose(a*x, b)
 
-    def test_solve_long_umfpack(self):
-        # Solve with UMFPACK: double precision, long indices
+    @dec.skipif(_is_32bit_platform)
+    def test_solve_int64_umfpack(self):
+        # Solve with UMFPACK: double precision, int64 indices
         a = _to_int64(self.a.astype('d'))
 
         b = self.b
@@ -86,8 +89,9 @@ class TestSolvers(object):
         x2 = lu.solve(self.b2)
         assert_allclose(a*x2, self.b2)
 
-    def test_splu_solve_long(self):
-        # Prefactorize (with UMFPACK) matrix with long indices for solving with
+    @dec.skipif(_is_32bit_platform)
+    def test_splu_solve_int64(self):
+        # Prefactorize (with UMFPACK) matrix with int64 indices for solving with
         # multiple rhs
         a = _to_int64(self.a.astype('d'))
         lu = um.splu(a)

--- a/scikits/umfpack/tests/test_umfpack.py
+++ b/scikits/umfpack/tests/test_umfpack.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-#
-
 """ Test functions for UMFPACK wrappers
 
 """

--- a/scikits/umfpack/tests/test_umfpack.py
+++ b/scikits/umfpack/tests/test_umfpack.py
@@ -17,6 +17,12 @@ from scipy.sparse.linalg import linsolve
 import numpy as np
 import scikits.umfpack as um
 
+# Force int64 index dtype even when indices fit into int32.
+def _to_int64(x):
+    y = csc_matrix(x).copy()
+    y.indptr = y.indptr.astype(np.int64)
+    y.indices = y.indices.astype(np.int64)
+    return y
 
 class _DeprecationAccept:
     def setUp(self):
@@ -40,10 +46,26 @@ class TestScipySolvers(_DeprecationAccept):
         x = linsolve.spsolve(a, b)
         assert_array_almost_equal(a*x, b)
 
+    def test_solve_complex_long_umfpack(self):
+        # Solve with UMFPACK: double precision complex, long indices
+        linsolve.use_solver(useUmfpack=True)
+        a = _to_int64(self.a.astype('D'))
+        b = self.b
+        x = linsolve.spsolve(a, b)
+        assert_array_almost_equal(a*x, b)
+
     def test_solve_umfpack(self):
         # Solve with UMFPACK: double precision
         linsolve.use_solver(useUmfpack=True)
         a = self.a.astype('d')
+        b = self.b
+        x = linsolve.spsolve(a, b)
+        assert_array_almost_equal(a*x, b)
+
+    def test_solve_long_umfpack(self):
+        # Solve with UMFPACK: double precision
+        linsolve.use_solver(useUmfpack=True)
+        a = _to_int64(self.a.astype('d'))
         b = self.b
         x = linsolve.spsolve(a, b)
         assert_array_almost_equal(a*x, b)
@@ -67,6 +89,17 @@ class TestScipySolvers(_DeprecationAccept):
         x2 = solve(self.b2)
         assert_array_almost_equal(a*x2, self.b2)
 
+    def test_factorized_long_umfpack(self):
+        # Prefactorize (with UMFPACK) matrix for solving with multiple rhs
+        linsolve.use_solver(useUmfpack=True)
+        a = _to_int64(self.a.astype('d'))
+        solve = linsolve.factorized(a)
+
+        x1 = solve(self.b)
+        assert_array_almost_equal(a*x1, self.b)
+        x2 = solve(self.b2)
+        assert_array_almost_equal(a*x2, self.b2)
+
     def test_factorized_without_umfpack(self):
         # Prefactorize matrix for solving with multiple rhs
         linsolve.use_solver(useUmfpack=False)
@@ -80,6 +113,7 @@ class TestScipySolvers(_DeprecationAccept):
 
     def setUp(self):
         self.a = spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1], 5, 5)
+        self.a2 = _to_int64(self.a)
         self.b = np.array([1, 2, 3, 4, 5], dtype=np.float64)
         self.b2 = np.array([5, 4, 3, 2, 1], dtype=np.float64)
 
@@ -94,6 +128,26 @@ class TestFactorization(_DeprecationAccept):
         umfpack = um.UmfpackContext("zi")
 
         for A in self.complex_matrices:
+            umfpack.numeric(A)
+
+            (L,U,P,Q,R,do_recip) = umfpack.lu(A)
+
+            L = L.todense()
+            U = U.todense()
+            A = A.todense()
+            if not do_recip:
+                R = 1.0/R
+            R = matrix(diag(R))
+            P = eye(A.shape[0])[P,:]
+            Q = eye(A.shape[1])[:,Q]
+
+            assert_array_almost_equal(P*R*A*Q,L*U)
+
+    def test_complex_long_lu(self):
+        # Getting factors of complex matrix with long indices
+        umfpack = um.UmfpackContext("zl")
+
+        for A in self.complex_long_matrices:
             umfpack.numeric(A)
 
             (L,U,P,Q,R,do_recip) = umfpack.lu(A)
@@ -129,23 +183,48 @@ class TestFactorization(_DeprecationAccept):
 
             assert_array_almost_equal(P*R*A*Q,L*U)
 
+    def test_real_long_lu(self):
+        # Getting factors of real matrix with long indices
+        umfpack = um.UmfpackContext("dl")
+
+        for A in self.real_long_matrices:
+            umfpack.numeric(A)
+
+            (L,U,P,Q,R,do_recip) = umfpack.lu(A)
+
+            L = L.todense()
+            U = U.todense()
+            A = A.todense()
+            if not do_recip:
+                R = 1.0/R
+            R = matrix(diag(R))
+            P = eye(A.shape[0])[P,:]
+            Q = eye(A.shape[1])[:,Q]
+
+            assert_array_almost_equal(P*R*A*Q,L*U)
+
     def setUp(self):
         random.seed(0)  # make tests repeatable
-        self.real_matrices = []
-        self.real_matrices.append(spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]],
-                                          [0, 1], 5, 5))
-        self.real_matrices.append(spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]],
-                                          [0, 1], 4, 5))
-        self.real_matrices.append(spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]],
-                                          [0, 2], 5, 5))
-        self.real_matrices.append(rand(3,3))
-        self.real_matrices.append(rand(5,4))
-        self.real_matrices.append(rand(4,5))
+        real_matrices = []
+        real_matrices.append(spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]],
+                                     [0, 1], 5, 5))
+        real_matrices.append(spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]],
+                                     [0, 1], 4, 5))
+        real_matrices.append(spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]],
+                                     [0, 2], 5, 5))
+        real_matrices.append(rand(3,3))
+        real_matrices.append(rand(5,4))
+        real_matrices.append(rand(4,5))
 
-        self.real_matrices = [csc_matrix(x).astype('d') for x
-                in self.real_matrices]
+        self.real_matrices = [csc_matrix(x).astype('d')
+                              for x in real_matrices]
         self.complex_matrices = [x.astype(np.complex128)
                                  for x in self.real_matrices]
+
+        self.real_long_matrices = [_to_int64(x)
+                                   for x in self.real_matrices]
+        self.complex_long_matrices = [_to_int64(x)
+                                      for x in self.complex_matrices]
 
         _DeprecationAccept.setUp(self)
 

--- a/scikits/umfpack/umfpack.i
+++ b/scikits/umfpack/umfpack.i
@@ -18,6 +18,7 @@
 
 #include <umfpack.h>
 
+typedef long UF_long;
 typedef long SuiteSparse_long;
 
 %init %{

--- a/scikits/umfpack/umfpack.i
+++ b/scikits/umfpack/umfpack.i
@@ -18,6 +18,8 @@
 
 #include <umfpack.h>
 
+typedef long SuiteSparse_long;
+
 %init %{
     import_array();
 %}
@@ -269,6 +271,18 @@ ARRAY_IN( int, int, INT )
     int Q [ ]
 };
 %apply int  *OUTPUT { int *do_recip};
+
+ARRAY_IN( long, long, LONG )
+%apply long *array {
+    long Lp [ ],
+    long Lj [ ],
+    long Up [ ],
+    long Ui [ ],
+    long P [ ],
+    long Q [ ]
+};
+%apply long *OUTPUT { long *do_recip};
+
 %include <umfpack_get_numeric.h>
 
 #endif


### PR DESCRIPTION
This PR tries to address #22.

It uses `typedef long SuiteSparse_long;` in `umfpack.i`, so it might not be portable - tested only on 64 bit linux for now.
