### PR TITLE
BLD: add pyproject.toml to be able to install with pip (PEP 518 support)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "numpy",
+]


### PR DESCRIPTION
Background: in setup.py numpy is imported, but it's not installed
in the isolated virtualenv that pip tries to build in.
And setup_requires is not implemented by pip.  So this is the way
to do it.

Try ``pip install .``, should fail without this PR and work with it.