### PR TITLE
Fix win amd64 dtypes

### DIFF
--- a/scikits/umfpack/interface.py
+++ b/scikits/umfpack/interface.py
@@ -21,7 +21,7 @@ from __future__ import division, print_function, absolute_import
 from warnings import warn
 import sys
 import numpy as np
-from numpy import asarray, empty, ravel, nonzero
+from numpy import asarray
 from scipy.sparse import (isspmatrix_csc, isspmatrix_csr, isspmatrix,
                           SparseEfficiencyWarning, csc_matrix, hstack)
 

--- a/scikits/umfpack/interface.py
+++ b/scikits/umfpack/interface.py
@@ -27,6 +27,12 @@ from scipy.sparse import (isspmatrix_csc, isspmatrix_csr, isspmatrix,
 
 from .umfpack import UmfpackContext, UMFPACK_A
 
+_families = {
+    (np.float64, np.int32): 'di',
+    (np.complex128, np.int32): 'zi',
+    (np.float64, np.int64): 'dl',
+    (np.complex128, np.int64): 'zl'
+}
 
 __all__ = ['spsolve', 'splu', 'UmfpackLU']
 
@@ -185,11 +191,18 @@ class UmfpackLU(object):
         if (M != N):
             raise ValueError("matrix must be square (has shape %s)" % ((M, N),))
 
-        if A.dtype.char not in 'dD':
-            raise ValueError("Only double precision matrices supported")
+        f_type = np.sctypeDict[A.dtype.name]
+        i_type = np.sctypeDict[A.indices.dtype.name]
+        try:
+            family = _families[(f_type, i_type)]
 
-        family = {'di': 'di', 'Di': 'zi', 'dl': 'dl', 'Dl': 'zl'}
-        self.umf = UmfpackContext(family[A.dtype.char + A.indices.dtype.char])
+        except KeyError:
+            msg = 'only float64 or complex128 matrices with int32 or int64' \
+                ' indices are supported! (got: matrix: %s, indices: %s)' \
+                % (f_type, i_type)
+            raise ValueError(msg)
+
+        self.umf = UmfpackContext(family)
         self.umf.numeric(A)
 
         self._A = A

--- a/scikits/umfpack/stdint.h
+++ b/scikits/umfpack/stdint.h
@@ -1,0 +1,245 @@
+// ISO C9x  compliant stdint.h for Microsoft Visual Studio
+// Based on ISO/IEC 9899:TC2 Committee draft (May 6, 2005) WG14/N1124 
+// 
+//  Copyright (c) 2006-2008 Alexander Chemeris
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//   1. Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+// 
+//   2. Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+// 
+//   3. The name of the author may be used to endorse or promote products
+//      derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+// EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef _MSC_VER
+    #ifndef _MSC_STDINT_H_ // [
+    #define _MSC_STDINT_H_
+
+    #if _MSC_VER > 1000
+    #pragma once
+    #endif
+
+    #include <limits.h>
+
+    // For Visual Studio 6 in C++ mode and for many Visual Studio versions when
+    // compiling for ARM we should wrap <wchar.h> include with 'extern "C++" {}'
+    // or compiler give many errors like this:
+    //   error C2733: second C linkage of overloaded function 'wmemchr' not allowed
+    #ifdef __cplusplus
+    extern "C" {
+    #endif
+    #  include <wchar.h>
+    #ifdef __cplusplus
+    }
+    #endif
+
+    // Define _W64 macros to mark types changing their size, like intptr_t.
+    #ifndef _W64
+    #  if !defined(__midl) && (defined(_X86_) || defined(_M_IX86)) && _MSC_VER >= 1300
+    #     define _W64 __w64
+    #  else
+    #     define _W64
+    #  endif
+    #endif
+
+
+    // 7.18.1 Integer types
+
+    // 7.18.1.1 Exact-width integer types
+
+    // Visual Studio 6 and Embedded Visual C++ 4 doesn't
+    // realize that, e.g. char has the same size as __int8
+    // so we give up on __intX for them.
+    #if (_MSC_VER < 1300)
+       typedef signed char       int8_t;
+       typedef signed short      int16_t;
+       typedef signed int        int32_t;
+       typedef unsigned char     uint8_t;
+       typedef unsigned short    uint16_t;
+       typedef unsigned int      uint32_t;
+    #else
+       typedef signed __int8     int8_t;
+       typedef signed __int16    int16_t;
+       typedef signed __int32    int32_t;
+       typedef unsigned __int8   uint8_t;
+       typedef unsigned __int16  uint16_t;
+       typedef unsigned __int32  uint32_t;
+    #endif
+    typedef signed __int64       int64_t;
+    typedef unsigned __int64     uint64_t;
+
+
+    // 7.18.1.2 Minimum-width integer types
+    typedef int8_t    int_least8_t;
+    typedef int16_t   int_least16_t;
+    typedef int32_t   int_least32_t;
+    typedef int64_t   int_least64_t;
+    typedef uint8_t   uint_least8_t;
+    typedef uint16_t  uint_least16_t;
+    typedef uint32_t  uint_least32_t;
+    typedef uint64_t  uint_least64_t;
+
+    // 7.18.1.3 Fastest minimum-width integer types
+    typedef int8_t    int_fast8_t;
+    typedef int16_t   int_fast16_t;
+    typedef int32_t   int_fast32_t;
+    typedef int64_t   int_fast64_t;
+    typedef uint8_t   uint_fast8_t;
+    typedef uint16_t  uint_fast16_t;
+    typedef uint32_t  uint_fast32_t;
+    typedef uint64_t  uint_fast64_t;
+
+    // 7.18.1.4 Integer types capable of holding object pointers
+    #ifdef _WIN64 // [
+       typedef signed __int64    intptr_t;
+       typedef unsigned __int64  uintptr_t;
+    #else // _WIN64 ][
+       typedef _W64 signed int   intptr_t;
+       typedef _W64 unsigned int uintptr_t;
+    #endif // _WIN64 ]
+
+    // 7.18.1.5 Greatest-width integer types
+    typedef int64_t   intmax_t;
+    typedef uint64_t  uintmax_t;
+
+
+    // 7.18.2 Limits of specified-width integer types
+
+    #if !defined(__cplusplus) || defined(__STDC_LIMIT_MACROS) // [   See footnote 220 at page 257 and footnote 221 at page 259
+
+    // 7.18.2.1 Limits of exact-width integer types
+    #define INT8_MIN     ((int8_t)_I8_MIN)
+    #define INT8_MAX     _I8_MAX
+    #define INT16_MIN    ((int16_t)_I16_MIN)
+    #define INT16_MAX    _I16_MAX
+    #define INT32_MIN    ((int32_t)_I32_MIN)
+    #define INT32_MAX    _I32_MAX
+    #define INT64_MIN    ((int64_t)_I64_MIN)
+    #define INT64_MAX    _I64_MAX
+    #define UINT8_MAX    _UI8_MAX
+    #define UINT16_MAX   _UI16_MAX
+    #define UINT32_MAX   _UI32_MAX
+    #define UINT64_MAX   _UI64_MAX
+
+    // 7.18.2.2 Limits of minimum-width integer types
+    #define INT_LEAST8_MIN    INT8_MIN
+    #define INT_LEAST8_MAX    INT8_MAX
+    #define INT_LEAST16_MIN   INT16_MIN
+    #define INT_LEAST16_MAX   INT16_MAX
+    #define INT_LEAST32_MIN   INT32_MIN
+    #define INT_LEAST32_MAX   INT32_MAX
+    #define INT_LEAST64_MIN   INT64_MIN
+    #define INT_LEAST64_MAX   INT64_MAX
+    #define UINT_LEAST8_MAX   UINT8_MAX
+    #define UINT_LEAST16_MAX  UINT16_MAX
+    #define UINT_LEAST32_MAX  UINT32_MAX
+    #define UINT_LEAST64_MAX  UINT64_MAX
+
+    // 7.18.2.3 Limits of fastest minimum-width integer types
+    #define INT_FAST8_MIN    INT8_MIN
+    #define INT_FAST8_MAX    INT8_MAX
+    #define INT_FAST16_MIN   INT16_MIN
+    #define INT_FAST16_MAX   INT16_MAX
+    #define INT_FAST32_MIN   INT32_MIN
+    #define INT_FAST32_MAX   INT32_MAX
+    #define INT_FAST64_MIN   INT64_MIN
+    #define INT_FAST64_MAX   INT64_MAX
+    #define UINT_FAST8_MAX   UINT8_MAX
+    #define UINT_FAST16_MAX  UINT16_MAX
+    #define UINT_FAST32_MAX  UINT32_MAX
+    #define UINT_FAST64_MAX  UINT64_MAX
+
+    // 7.18.2.4 Limits of integer types capable of holding object pointers
+    #ifdef _WIN64 // [
+    #  define INTPTR_MIN   INT64_MIN
+    #  define INTPTR_MAX   INT64_MAX
+    #  define UINTPTR_MAX  UINT64_MAX
+    #else // _WIN64 ][
+    #  define INTPTR_MIN   INT32_MIN
+    #  define INTPTR_MAX   INT32_MAX
+    #  define UINTPTR_MAX  UINT32_MAX
+    #endif // _WIN64 ]
+
+    // 7.18.2.5 Limits of greatest-width integer types
+    #define INTMAX_MIN   INT64_MIN
+    #define INTMAX_MAX   INT64_MAX
+    #define UINTMAX_MAX  UINT64_MAX
+
+    // 7.18.3 Limits of other integer types
+
+    #ifdef _WIN64 // [
+    #  define PTRDIFF_MIN  _I64_MIN
+    #  define PTRDIFF_MAX  _I64_MAX
+    #else  // _WIN64 ][
+    #  define PTRDIFF_MIN  _I32_MIN
+    #  define PTRDIFF_MAX  _I32_MAX
+    #endif  // _WIN64 ]
+
+    #define SIG_ATOMIC_MIN  INT_MIN
+    #define SIG_ATOMIC_MAX  INT_MAX
+
+    #ifndef SIZE_MAX // [
+    #  ifdef _WIN64 // [
+    #     define SIZE_MAX  _UI64_MAX
+    #  else // _WIN64 ][
+    #     define SIZE_MAX  _UI32_MAX
+    #  endif // _WIN64 ]
+    #endif // SIZE_MAX ]
+
+    // WCHAR_MIN and WCHAR_MAX are also defined in <wchar.h>
+    #ifndef WCHAR_MIN // [
+    #  define WCHAR_MIN  0
+    #endif  // WCHAR_MIN ]
+    #ifndef WCHAR_MAX // [
+    #  define WCHAR_MAX  _UI16_MAX
+    #endif  // WCHAR_MAX ]
+
+    #define WINT_MIN  0
+    #define WINT_MAX  _UI16_MAX
+
+    #endif // __STDC_LIMIT_MACROS ]
+
+
+    // 7.18.4 Limits of other integer types
+
+    #if !defined(__cplusplus) || defined(__STDC_CONSTANT_MACROS) // [   See footnote 224 at page 260
+
+    // 7.18.4.1 Macros for minimum-width integer constants
+
+    #define INT8_C(val)  val##i8
+    #define INT16_C(val) val##i16
+    #define INT32_C(val) val##i32
+    #define INT64_C(val) val##i64
+
+    #define UINT8_C(val)  val##ui8
+    #define UINT16_C(val) val##ui16
+    #define UINT32_C(val) val##ui32
+    #define UINT64_C(val) val##ui64
+
+    // 7.18.4.2 Macros for greatest-width integer constants
+    #define INTMAX_C   INT64_C
+    #define UINTMAX_C  UINT64_C
+
+    #endif // __STDC_CONSTANT_MACROS ]
+
+
+    #endif // _MSC_STDINT_H_ ]
+#endif

--- a/scikits/umfpack/umfpack.i
+++ b/scikits/umfpack/umfpack.i
@@ -12,14 +12,27 @@
 %{
 #include <umfpack.h>
 #include "numpy/arrayobject.h"
+#include "stdint.h"
 %}
+
+%include "stdint.i"
 
 %feature("autodoc", "1");
 
 #include <umfpack.h>
 
-typedef long UF_long;
-typedef long SuiteSparse_long;
+typedef int64_t UF_long;
+typedef int64_t SuiteSparse_long;
+
+/* Convert from Python --> C */
+%typemap(in) SuiteSparse_long {
+  $1 = (SuiteSparse_long)PyInt_AsLong($input);
+}
+
+/* Convert from C --> Python */
+%typemap(out) SuiteSparse_long {
+  $result = PyInt_FromLong((int)$1);
+}
 
 %init %{
     import_array();
@@ -166,6 +179,12 @@ ARRAY_IN( long, const long, LONG )
     const long Ai [ ]
 };
 
+ARRAY_IN( SuiteSparse_long, const SuiteSparse_long, INT64 )
+%apply const SuiteSparse_long *array {
+    const SuiteSparse_long Ap [ ],
+    const SuiteSparse_long Ai [ ]
+};
+
 ARRAY_IN( double, const double, DOUBLE )
 %apply const double *array {
     const double Ax [ ],
@@ -248,8 +267,14 @@ OPAQUE_ARGINOUT( void * )
     long *n_col,
     long *nz_udiag
 };
+%apply long *OUTPUT {
+    SuiteSparse_long *lnz,
+    SuiteSparse_long *unz,
+    SuiteSparse_long *n_row,
+    SuiteSparse_long *n_col,
+    SuiteSparse_long *nz_udiag
+};
 %include <umfpack_get_lunz.h>
-
 
 ARRAY_IN( double, double, DOUBLE )
 %apply double *array {
@@ -283,6 +308,17 @@ ARRAY_IN( long, long, LONG )
     long Q [ ]
 };
 %apply long *OUTPUT { long *do_recip};
+
+ARRAY_IN( SuiteSparse_long, SuiteSparse_long, INT64 )
+%apply SuiteSparse_long *array {
+    SuiteSparse_long Lp [ ],
+    SuiteSparse_long Lj [ ],
+    SuiteSparse_long Up [ ],
+    SuiteSparse_long Ui [ ],
+    SuiteSparse_long P [ ],
+    SuiteSparse_long Q [ ]
+};
+%apply long *OUTPUT { SuiteSparse_long *do_recip};
 
 %include <umfpack_get_numeric.h>
 

--- a/scikits/umfpack/umfpack.py
+++ b/scikits/umfpack/umfpack.py
@@ -505,16 +505,16 @@ class UmfpackContext(Struct):
         if self.isReal:
             status, self._symbolic\
                     = self.funs.symbolic(mtx.shape[0], mtx.shape[1],
-                                          mtx.indptr.astype('int32'),
-                                          indx.astype('int32'),
+                                          mtx.indptr,
+                                          indx,
                                           mtx.data,
                                           self.control, self.info)
         else:
             real, imag = mtx.data.real.copy(), mtx.data.imag.copy()
             status, self._symbolic\
                     = self.funs.symbolic(mtx.shape[0], mtx.shape[1],
-                                          mtx.indptr.astype('int32'),
-                                          indx.astype('int32'),
+                                          mtx.indptr,
+                                          indx,
                                           real, imag,
                                           self.control, self.info)
 

--- a/scikits/umfpack/umfpack.py
+++ b/scikits/umfpack/umfpack.py
@@ -469,19 +469,19 @@ class UmfpackContext(Struct):
         ##
         # Should check types of indices to correspond to familyTypes.
         if self.family[1] == 'i':
-            if (indx.dtype != np.dtype('i')) \
-                   or mtx.indptr.dtype != np.dtype('i'):
+            if (indx.dtype != np.dtype(np.int32)) \
+                   or mtx.indptr.dtype != np.dtype(np.int32):
                 raise ValueError('matrix must have int indices')
         else:
-            if (indx.dtype != np.dtype('l')) \
-                   or mtx.indptr.dtype != np.dtype('l'):
+            if (indx.dtype != np.dtype(np.int64)) \
+                   or mtx.indptr.dtype != np.dtype(np.int64):
                 raise ValueError('matrix must have long indices')
 
         if self.isReal:
-            if mtx.data.dtype != np.dtype('f8'):
+            if mtx.data.dtype != np.dtype(np.float64):
                 raise ValueError('matrix must have float64 values')
         else:
-            if mtx.data.dtype != np.dtype('c16'):
+            if mtx.data.dtype != np.dtype(np.complex128):
                 raise ValueError('matrix must have complex128 values')
 
         return indx

--- a/scikits/umfpack/umfpack.py
+++ b/scikits/umfpack/umfpack.py
@@ -505,13 +505,16 @@ class UmfpackContext(Struct):
         if self.isReal:
             status, self._symbolic\
                     = self.funs.symbolic(mtx.shape[0], mtx.shape[1],
-                                          mtx.indptr, indx, mtx.data,
+                                          mtx.indptr.astype('int32'),
+                                          indx.astype('int32'),
+                                          mtx.data,
                                           self.control, self.info)
         else:
             real, imag = mtx.data.real.copy(), mtx.data.imag.copy()
             status, self._symbolic\
                     = self.funs.symbolic(mtx.shape[0], mtx.shape[1],
-                                          mtx.indptr, indx,
+                                          mtx.indptr.astype('int32'),
+                                          indx.astype('int32'),
                                           real, imag,
                                           self.control, self.info)
 


### PR DESCRIPTION
Building on top of the work by @rc, we fix the windows compilation issues through using the C99 `int64_t` type that is supported in both windows and linux. Specifically, we apply the typemaps assigned to long to our new type with `apply long`:

```
+%apply long *OUTPUT {
```

We also tell swig how to convert Python integers to our new type:

```
%typemap(out) SuiteSparse_long {
  $result = PyInt_FromLong((int)$1);
}
```

The result is that we can compile both on windows and linux.

Closes #37.
Closes #36.