### PR TITLE
setup: set the correct install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ def setup_package():
         import numpy
         INSTALL_REQUIRES = [
             'numpy>=' + str(numpy.__version__),
-            'scipy,
+            'scipy',
         ]
     except ImportError:
         INSTALL_REQUIRES = []

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,15 @@ def setup_package():
         except ImportError:
             pass
 
+    try:
+        import numpy
+        INSTALL_REQUIRES = [
+            'numpy>=' + str(numpy.__version__),
+            'scipy,
+        ]
+    except ImportError:
+        INSTALL_REQUIRES = []
+
     metadata = dict(name=DISTNAME,
                     maintainer=MAINTAINER,
                     maintainer_email=MAINTAINER_EMAIL,
@@ -122,6 +131,7 @@ def setup_package():
                     version=VERSION,
                     download_url=DOWNLOAD_URL,
                     long_description=LONG_DESCRIPTION,
+                    install_requires=INSTALL_REQUIRES,
                     classifiers=[
                         'Development Status :: 4 - Beta',
                         'Environment :: Console',


### PR DESCRIPTION
The minimum required numpy version is dynamically set based on the
version of numpy that scikit-umfpack is compiled against, ensuring that ABI compatibility
is preserved.