### PR TITLE
NumPy 1.25 compatibility fixes

### DIFF
--- a/scikits/umfpack/__init__.py
+++ b/scikits/umfpack/__init__.py
@@ -22,5 +22,3 @@ if __doc__ is not None:
     del _umfpack_doc, _interface_doc
 
 __all__ = [s for s in dir() if not s.startswith('_')]
-from numpy.testing import Tester
-test = Tester().test

--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import unittest
 
-from numpy.testing import assert_allclose, run_module_suite
+from numpy.testing import assert_allclose
 from numpy.linalg import norm as dense_norm
 
 from scipy.sparse import csc_matrix, spdiags, SparseEfficiencyWarning
@@ -133,4 +133,4 @@ class TestSolvers(unittest.TestCase):
         assert_allclose(A2, A.A, atol=1e-13)
 
 if __name__ == "__main__":
-    run_module_suite()
+    unittest.main()

--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import warnings
 import unittest
 
-from numpy.testing import assert_allclose, run_module_suite, dec
+from numpy.testing import assert_allclose, run_module_suite
 from numpy.linalg import norm as dense_norm
 
 from scipy.sparse import csc_matrix, spdiags, SparseEfficiencyWarning
@@ -47,7 +47,7 @@ class TestSolvers(unittest.TestCase):
         x = um.spsolve(a, b)
         assert_allclose(a*x, b)
 
-    @dec.skipif(_is_32bit_platform)
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_solve_complex_int64_umfpack(self):
         # Solve with UMFPACK: double precision complex, int64 indices
         a = _to_int64(self.a.astype('D'))
@@ -62,7 +62,7 @@ class TestSolvers(unittest.TestCase):
         x = um.spsolve(a, b)
         assert_allclose(a*x, b)
 
-    @dec.skipif(_is_32bit_platform)
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_solve_int64_umfpack(self):
         # Solve with UMFPACK: double precision, int64 indices
         a = _to_int64(self.a.astype('d'))
@@ -88,7 +88,7 @@ class TestSolvers(unittest.TestCase):
         x2 = lu.solve(self.b2)
         assert_allclose(a*x2, self.b2)
 
-    @dec.skipif(_is_32bit_platform)
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_splu_solve_int64(self):
         # Prefactorize (with UMFPACK) matrix with int64 indices for solving with
         # multiple rhs

--- a/scikits/umfpack/tests/test_umfpack.py
+++ b/scikits/umfpack/tests/test_umfpack.py
@@ -8,7 +8,7 @@ import random
 import unittest
 import warnings
 
-from numpy.testing import assert_array_almost_equal, run_module_suite, dec
+from numpy.testing import assert_array_almost_equal, run_module_suite
 
 from scipy import rand, matrix, diag, eye
 from scipy.sparse import csc_matrix, linalg, spdiags, SparseEfficiencyWarning
@@ -50,7 +50,7 @@ class TestScipySolvers(_DeprecationAccept):
         x = linalg.spsolve(a, b)
         assert_array_almost_equal(a*x, b)
 
-    @dec.skipif(_is_32bit_platform)
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_solve_complex_long_umfpack(self):
         # Solve with UMFPACK: double precision complex, long indices
         linalg.use_solver(useUmfpack=True)
@@ -67,7 +67,7 @@ class TestScipySolvers(_DeprecationAccept):
         x = linalg.spsolve(a, b)
         assert_array_almost_equal(a*x, b)
 
-    @dec.skipif(_is_32bit_platform)
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_solve_long_umfpack(self):
         # Solve with UMFPACK: double precision
         linalg.use_solver(useUmfpack=True)
@@ -95,7 +95,7 @@ class TestScipySolvers(_DeprecationAccept):
         x2 = solve(self.b2)
         assert_array_almost_equal(a*x2, self.b2)
 
-    @dec.skipif(_is_32bit_platform)
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_factorized_long_umfpack(self):
         # Prefactorize (with UMFPACK) matrix for solving with multiple rhs
         linalg.use_solver(useUmfpack=True)
@@ -150,7 +150,7 @@ class TestFactorization(_DeprecationAccept):
 
             assert_array_almost_equal(P*R*A*Q,L*U)
 
-    @dec.skipif(_is_32bit_platform)
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_complex_int64_lu(self):
         # Getting factors of complex matrix with long indices
         umfpack = um.UmfpackContext("zl")
@@ -191,7 +191,7 @@ class TestFactorization(_DeprecationAccept):
 
             assert_array_almost_equal(P*R*A*Q,L*U)
 
-    @dec.skipif(_is_32bit_platform)
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_real_int64_lu(self):
         # Getting factors of real matrix with long indices
         umfpack = um.UmfpackContext("dl")

--- a/scikits/umfpack/tests/test_umfpack.py
+++ b/scikits/umfpack/tests/test_umfpack.py
@@ -8,7 +8,7 @@ import random
 import unittest
 import warnings
 
-from numpy.testing import assert_array_almost_equal, run_module_suite
+from numpy.testing import assert_array_almost_equal
 
 from scipy import rand, matrix, diag, eye
 from scipy.sparse import csc_matrix, linalg, spdiags, SparseEfficiencyWarning
@@ -239,4 +239,4 @@ class TestFactorization(_DeprecationAccept):
 
 
 if __name__ == "__main__":
-    run_module_suite()
+    unittest.main()


### PR DESCRIPTION
NumPy dropped nose support in https://github.com/numpy/numpy/pull/23041. Those two patches remove the problematic code and make the package tests NumPy 1.25 compatible. One of those patches was originally created by @s-t-e-v-e-n-k, the other by me. Those are just rough fixes, you may want to refine the changes before the next release.