### PR TITLE
meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,34 @@
+project(
+  'scikits.umfpack',
+  'c',
+  version: '0.3.4',
+  license: 'BSD',
+)
+
+py = import('python').find_installation(pure: false)
+
+cc = meson.get_compiler('c')
+
+swig = find_program('swig', required: true, native: true)
+
+blas_deps = []
+if host_machine.system() == 'darwin'
+  blas_deps = [dependency('Accelerate')]
+else
+  blas_deps = [cc.find_library('openblas', required : false)]
+endif
+if not blas_deps[0].found()
+    blas_deps = [cc.find_library('blas')]
+    cblas_dep = cc.find_library('cblas', required : false)
+    if cblas_dep.found()
+        blas_deps += cblas_dep
+    endif
+endif
+
+# Find UMFPACK library.
+umfpack_dep = cc.find_library('umfpack', required : true,
+                              has_headers : ['suitesparse/umfpack.h'])
+amd_dep = cc.find_library('amd', required : true,
+                          has_headers : ['suitesparse/amd.h'])
+
+subdir('scikits')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
-[build-system]
-requires = [
-    "wheel",
-    "setuptools",
-    "numpy",
-]
+build-backend = 'mesonpy'
+requires = ['meson-python', 'numpy']
+
+[project]
+name = 'scikit-umfpack'
+version = "0.3.4"

--- a/scikits/meson.build
+++ b/scikits/meson.build
@@ -1,0 +1,3 @@
+py.install_sources('__init__.py', subdir: 'scikits')
+
+subdir('umfpack')

--- a/scikits/umfpack/meson.build
+++ b/scikits/umfpack/meson.build
@@ -1,0 +1,27 @@
+# This uses the path as is, and avoids running the interpreter.
+incdir_numpy = run_command(py,['-c',
+'''import os
+import numpy as np
+try:
+  incdir = os.path.relpath(np.get_include())
+except Exception:
+  incdir = np.get_include()
+print(incdir)
+'''], check: true).stdout().strip()
+
+_umfpack_swig = custom_target('_umfpack_swig',
+    output: ['_umfpack_wrap.c'],
+    input: 'umfpack.i',
+    command: [swig, '-python', '-I/usr/include/suitesparse',
+              '-o', '@OUTPUT@', '@INPUT@']
+  )
+
+__umfpack = py.extension_module(
+    '__umfpack',
+    _umfpack_swig,
+
+    include_directories: ['/usr/include/suitesparse', incdir_numpy],
+    dependencies: [blas_deps, umfpack_dep, amd_dep],
+    install: true,
+    subdir: 'scikits/umfpack'
+)


### PR DESCRIPTION
See #89, switching from deprecated numpy.distutils to meson should help fixing the pip installation problems and allow a new release.
