### PR TITLE
Fix build with Clang and MSVC, and add macOS and Windows CI jobs

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Build a wheel
       run: |
-        python -m build --wheel
+        python -m build  # builds sdist, and then wheel from sdist
         pip install dist/scikit*.whl
 
     - name: Run test suite
@@ -56,36 +56,33 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-    - name: Setup Conda environment
-      uses: conda-incubator/setup-miniconda@v2
+    - uses: mamba-org/setup-micromamba@v1
       with:
-        python-version: '3.12'
-        channels: conda-forge
-        channel-priority: true
-        activate-environment: scikit-umfpack-dev
-        use-only-tar-bz2: false
-        miniforge-variant: Mambaforge
-        miniforge-version: latest
-        use-mamba: true
-
-    - name: Update Conda Environment
-      run: |
-        mamba env update -n scikit-umfpack-dev -f environment.yml
+        environment-file: environment.yml
+        cache-environment: true
 
     - name: Build a wheel
       shell: bash -el {0}
       run: |
-        conda activate scikit-umfpack-dev
-        python -m build --no-isolation
-        pip install dist/scikit*.whl --no-deps
+        micromamba activate scikit-umfpack-dev
+        if [[ ${{ matrix.platform }} == windows-latest ]]; then
+          pip install . -v --no-build-isolation -Cbuild-dir=build -Csetup-args=--vsenv -Csetup-args=--native-file=$PWD/tools/ci/windows-condaforge-native.ini
+        else
+          pip install . -v --no-build-isolation -Cbuild-dir=build
+        fi
 
     - name: Run test suite
       shell: bash -el {0}
       run: |
-        conda activate scikit-umfpack-dev
+        micromamba activate scikit-umfpack-dev
         cd docs
         pytest --pyargs scikits.umfpack
+
+    - name: Show meson-log.txt
+      if: failure()
+      run: |
+        cat build/meson-logs/meson-log.txt

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -51,7 +51,12 @@ jobs:
 
   conda-forge:
     if: "github.repository == 'scikit-umfpack/scikit-umfpack'"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/README.rst
+++ b/README.rst
@@ -33,55 +33,75 @@ References
        Mathematical Software, 30(3), 2004, pp. 377--380.
        https://doi.org/10.1145/1024074.1024080
 
-Dependencies
-============
-
-scikit-umfpack depends on NumPy, SciPy, SuiteSparse, and swig is a
-build-time dependency.
-
-Building SuiteSparse
---------------------
-
-SuiteSparse may be available from your package manager or as a prebuilt
-shared library. If that is the case use that if possible. Installation
-on Ubuntu 14.04 can be achieved with
-
-::
-
-    sudo apt-get install libsuitesparse-dev
-
-Otherwise, you will need to build from source. Unfortunately,
-SuiteSparse's makefiles do not support building a shared library out of
-the box. You may find `Stefan Fuertinger instructions
-helpful <http://fuertinger.lima-city.de/research.html#building-numpy-and-scipy>`__.
-
-Furthmore, building METIS-4.0, an optional but important compile time
-dependency of SuiteSparse, has problems on newer GCCs. This `patch and
-instructions <http://www.math-linux.com/mathematics/linear-systems/article/how-to-patch-metis-4-0-error-conflicting-types-for-__log2>`__
-from Nadir Soualem are helpful for getting a working METIS build.
-
-Otherwise, I commend you to the documentation.
-
 Installation
 ============
 
 .. include-start
 
-Releases of scikit-umfpack can be installed using ``pip``. For a system-wide
-installation run::
+Releases of scikit-umfpack can be installed from source using ``pip``, or with
+a package manager like ``conda`` . To install from source, first ensure the
+dependencies described in the next section are installed, then run::
 
-  pip install --upgrade scikit-umfpack
+  pip install scikit-umfpack
 
-or for a user installation run ::
+To install scikit-umfpack from its source code directory, run in the root of
+a clone of the Git repository::
 
-  pip install --upgrade --user scikit-umfpack
+  pip install .
 
-To install scikit-umfpack from its source code directory, run in that
-directory (``--user`` means a user installation)::
+Dependencies
+------------
 
-  pip install --upgrade --user .
+scikit-umfpack depends on NumPy, SciPy, and SuiteSparse.
+
+To build scikit-umfpack, the following are needed:
+- a C compiler
+- a BLAS library with CBLAS symbols (e.g., OpenBLAS, Accelerate on macOS, or reference BLAS)
+- NumPy
+- SuiteSparse (which contains UMFPACK)
+- SWIG
+
+pkg-config is an optional dependency, if it's installed it may be used to
+detect a BLAS library.
+
+SuiteSparse cannot be installed from PyPI, however it will likely be available
+from your package manager of choice. E.g., installing on Ubuntu 22.04 can be
+achieved with::
+
+    sudo apt-get install libsuitesparse-dev
+
+or from Conda-forge on any supported OS with::
+
+    conda install suitesparse
+
+SuiteSparse can also be built from source, see the instructions in the README
+of the `SuiteSparse repository <https://github.com/DrTimothyAldenDavis/SuiteSparse>`__.
+
+
+Detection of UMFPACK
+''''''''''''''''''''
+
+During the build, scikit-umfpack tries to automatically detect the UMFPACK
+shared library and headers. In case SuiteSparse is installed in a non-standard
+location, this autodetection may fail. If that happens, it is possible to
+provide the paths to the library and include directories in a config file (a
+Meson machine file). This file should contain absolute paths. For example, for
+a conda env on Windows, it may look like:
+
+.. code:: ini
+
+    [properties]
+    umfpack-libdir = 'C:\Users\micromamba\envs\scikit-umfpack-dev\Library\lib'
+    umfpack-includedir = 'C:\Users\micromamba\envs\scikit-umfpack-dev\Library\include\suitesparse'
+
+If that file is named ``nativefile.ini``, then the ``pip`` invocation should
+look like (note that ``$PWD`` ensures an absolute path to the native file is
+used)::
+
+    pip install . -Csetup-args=--native-file=$PWD/nativefile.ini
 
 .. include-end
+
 
 Development
 ===========

--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,5 @@ dependencies:
   - swig
   - build
   - pytest
+  - openblas
+  - pkg-config

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,37 @@ if not blas_deps[0].found()
     endif
 endif
 
+# The list of paths here was taken over from numpy.distutils.system_info.py:
+_try_incdirs = [
+    '/usr/include/suitesparse',
+    '/usr/local/include',
+    '/opt/include',
+    '/opt/local/include/ufsparse',
+    '/opt/local/include',
+    '/sw/include',
+    '/usr/include/suitesparse'
+]
+suitesparse_incdirs = []
+umfpack_header_dirs = []
+foreach _dir : _try_incdirs
+  if fs.exists(_dir)
+    suitesparse_incdirs += _dir
+    umfpack_header_dirs += include_directories(_dir)
+  endif
+endforeach
+
+# TODO
+umfpack_libdirs = []
+umfpack_libdir = meson.get_external_property('umfpack-libdir', 'UNKNOWN')
+umfpack_includedir = meson.get_external_property('umfpack-includedir', 'UNKNOWN')
+if umfpack_libdir != 'UNKNOWN'
+    umfpack_libdirs += umfpack_libdir
+endif
+if umfpack_includedir != 'UNKNOWN'
+    suitesparse_incdirs += umfpack_includedir
+    umfpack_header_dirs += include_directories(umfpack_includedir)
+endif
+
 # Find UMFPACK library.
 # Note that Suitesparse packaging is messy; the headers may be found under
 # either `<prefix>/include/` or <prefix>/suitesparse/include`. Conda-forge does
@@ -45,26 +76,9 @@ endif
 umfpack_dep = dependency('UMFPACK', required: false)
 if not umfpack_dep.found()
   # Using pkg-config or CMake didn't work, so try the "manual" way.
-  # The list of paths here was taken over from numpy.distutils.system_info.py:
-  _try_incdirs = [
-      '/usr/include/suitesparse',
-      '/usr/local/include',
-      '/opt/include',
-      '/opt/local/include/ufsparse',
-      '/opt/local/include',
-      '/sw/include',
-      '/usr/include/suitesparse'
-  ]
-  suitesparse_incdirs = []
-  umfpack_header_dirs = []
-  foreach _dir : _try_incdirs
-    if fs.exists(_dir)
-      suitesparse_incdirs += _dir
-      umfpack_header_dirs += include_directories(_dir)
-    endif
-  endforeach
   umfpack_lib = cc.find_library('umfpack',
       required : true,
+      dirs: umfpack_libdirs,
       header_include_directories: umfpack_header_dirs,
       has_headers : ['umfpack.h']
   )

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,10 @@ blas_deps = []
 if host_machine.system() == 'darwin'
   blas_deps = [dependency('Accelerate')]
 else
-  blas_deps = [cc.find_library('openblas', required : false)]
+  blas_deps = [dependency('openblas', required : false)]  # try with pkg-config first
+  if not blas_deps[0].found()
+    blas_deps = [cc.find_library('openblas', required : false)]
+  endif
 endif
 if not blas_deps[0].found()
     blas_deps = [cc.find_library('blas')]

--- a/scikits/umfpack/meson.build
+++ b/scikits/umfpack/meson.build
@@ -14,12 +14,30 @@ swig_inc_args = []
 foreach _dir : suitesparse_incdirs
     swig_inc_args += '-I' + _dir
 endforeach
-# This is a hack that gets at the location for conda envs, when building with
-# conda compilers. We need proper SWIG support for this to become more robust,
-# see https://github.com/mesonbuild/meson/issues/341.
-_cc_incdir = run_command([cc, '-print-sysroot'], check: true).stdout().strip()
-if _cc_incdir.contains('bin/../')
- swig_inc_args += '-I' + _cc_incdir.split('bin/../')[0] / 'include'
+
+# This is a hack that gets at the location for conda envs (and perhaps other
+# types of envs), when building with conda compilers. We need proper SWIG
+# support for this to become more robust, see
+# https://github.com/mesonbuild/meson/issues/341.
+if cc.get_id() == 'gcc'
+    _cc_sysroot = run_command([cc, '-print-sysroot'], check: true).stdout().strip()
+    if _cc_sysroot.contains('bin/../')
+       _incdir = _cc_sysroot.split('bin/../')[0] / 'include'
+       if fs.exists(_incdir)
+           swig_inc_args += '-I' + _incdir
+       endif
+    endif
+elif cc.get_id() == 'clang'
+    _clang_v = run_command([cc, '-v'], check: true).stderr().strip()
+    if _clang_v.contains('InstalledDir: ')
+        _bindir = _clang_v.split('InstalledDir: ')[1]
+        if fs.exists(_bindir)
+            _incdir = _bindir / '../include'
+            if fs.exists(_incdir)
+                swig_inc_args += '-I' + _incdir
+            endif
+        endif
+    endif
 endif
 # The above took care of all fixed directories. We also need the default
 # compiler search directories, but Meson doesn't expose those.

--- a/tools/ci/windows-condaforge-native.ini
+++ b/tools/ci/windows-condaforge-native.ini
@@ -1,0 +1,7 @@
+[built-in options]
+libdir = 'C:\Users\runneradmin\micromamba\envs\scikit-umfpack-dev\Library\lib'
+includedir = 'C:\Users\runneradmin\micromamba\envs\scikit-umfpack-dev\Library\include'
+
+[properties]
+umfpack-libdir = 'C:\Users\runneradmin\micromamba\envs\scikit-umfpack-dev\Library\lib'
+umfpack-includedir = 'C:\Users\runneradmin\micromamba\envs\scikit-umfpack-dev\Library\include\suitesparse'


### PR DESCRIPTION
Other changes:
- update the build/install info in the docs
- switch to `setup-micromamba` and enable caching for faster CI jobs
- add a way for users to provide paths to a custom location of UMFPACK via a Meson native file
- use `pkg-config` for BLAS detection to make that more robust

Closes gh-94