### PR TITLE
FEAT: accept csc and csr arrays in scipy >= 1.10

### DIFF
--- a/scikits/umfpack/interface.py
+++ b/scikits/umfpack/interface.py
@@ -240,7 +240,6 @@ class UmfpackLU(object):
 
         if b.shape[0] != self._A.shape[1]:
             raise ValueError("Shape of b is not compatible with that of A")
-        
         b_arr = asarray(b, dtype=self._A.dtype).reshape(b.shape[0], -1)
         x = np.zeros((self._A.shape[0], b_arr.shape[1]), dtype=self._A.dtype)
         for j in range(b_arr.shape[1]):

--- a/scikits/umfpack/interface.py
+++ b/scikits/umfpack/interface.py
@@ -21,8 +21,9 @@ from __future__ import division, print_function, absolute_import
 from warnings import warn
 import sys
 import numpy as np
+import scipy.sparse as sparse
 from numpy import asarray
-from scipy.sparse import (isspmatrix_csc, isspmatrix_csr, isspmatrix,
+from scipy.sparse import (isspmatrix_csc, isspmatrix_csr, issparse,
                           SparseEfficiencyWarning, csc_matrix, hstack)
 
 from .umfpack import UmfpackContext, UMFPACK_A
@@ -179,7 +180,14 @@ class UmfpackLU(object):
     """
 
     def __init__(self, A):
-        if not (isspmatrix_csc(A) or isspmatrix_csr(A)):
+        if not (
+            isspmatrix_csc(A)
+            or isspmatrix_csr(A)
+            or (
+                hasattr(sparse, "csc_array")
+                and (isinstance(A, sparse.csc_array) or isinstance(A, sparse.csr_array))
+            )
+        ):
             A = csc_matrix(A)
             warn('spsolve requires A be CSC or CSR matrix format',
                     SparseEfficiencyWarning)
@@ -227,12 +235,12 @@ class UmfpackLU(object):
             Solution to the matrix equation
 
         """
-        if isspmatrix(b):
+        if issparse(b):
             b = b.toarray()
 
         if b.shape[0] != self._A.shape[1]:
             raise ValueError("Shape of b is not compatible with that of A")
-
+        
         b_arr = asarray(b, dtype=self._A.dtype).reshape(b.shape[0], -1)
         x = np.zeros((self._A.shape[0], b_arr.shape[1]), dtype=self._A.dtype)
         for j in range(b_arr.shape[1]):

--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -6,7 +6,7 @@ import unittest
 from numpy.testing import assert_allclose
 from numpy.linalg import norm as dense_norm
 
-from scipy.sparse import csc_matrix, spdiags, SparseEfficiencyWarning
+from scipy.sparse import csc_array, csc_matrix, spdiags, SparseEfficiencyWarning
 from scipy.sparse import hstack
 
 import numpy as np
@@ -17,8 +17,11 @@ _is_32bit_platform = np.intp(0).itemsize < 8
 
 
 # Force int64 index dtype even when indices fit into int32.
-def _to_int64(x):
-    y = csc_matrix(x).copy()
+def _to_int64(x, array=False):
+    if array:
+        y = csc_array(x).copy()
+    else:
+        y = csc_matrix(x).copy()
     y.indptr = y.indptr.astype(np.int64)
     y.indices = y.indices.astype(np.int64)
     return y
@@ -129,6 +132,118 @@ class TestSolvers(unittest.TestCase):
         R.setdiag(lu.R)
 
         A2 = (R * Pr.T * (lu.L * lu.U) * Pc.T).A
+
+        assert_allclose(A2, A.A, atol=1e-13)
+
+class TestSolversWithArrays(unittest.TestCase):
+    """Same tests as above, but using the csc_array interface. 
+    
+    Key difference is that sparse arrays support matrix multiplication with
+    the @ operator rather than the * operator.
+    """
+
+    def setUp(self):
+        self.a = spdiags([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1], 5, 5)
+        self.b = np.array([1, 2, 3, 4, 5], dtype=np.float64)
+        self.b2 = np.array([5, 4, 3, 2, 1], dtype=np.float64)
+
+        self.mgr = warnings.catch_warnings()
+        self.mgr.__enter__()
+
+        warnings.simplefilter('ignore', SparseEfficiencyWarning)
+
+    def tearDown(self):
+        self.mgr.__exit__()
+
+    def test_solve_complex_umfpack(self):
+        # Solve with UMFPACK: double precision complex
+        a = self.a.astype('D')
+        b = self.b
+        x = um.spsolve(a, b)
+        assert_allclose(a@x, b)
+
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
+    def test_solve_complex_int64_umfpack(self):
+        # Solve with UMFPACK: double precision complex, int64 indices
+        a = _to_int64(self.a.astype('D'), array=True)
+        b = self.b
+        x = um.spsolve(a, b)
+        assert_allclose(a @ x, b)
+
+    def test_solve_umfpack(self):
+        # Solve with UMFPACK: double precision
+        a = self.a.astype('d')
+        b = self.b
+        x = um.spsolve(a, b)
+        assert_allclose(a @ x, b)
+
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
+    def test_solve_int64_umfpack(self):
+        # Solve with UMFPACK: double precision, int64 indices
+        a = _to_int64(self.a.astype('d'), array=True)
+
+        b = self.b
+        x = um.spsolve(a, b)
+        assert_allclose(a @ x, b)
+
+    def test_solve_sparse_rhs(self):
+        # Solve with UMFPACK: double precision, sparse rhs
+        a = self.a.astype('d')
+        b = csc_array(self.b).T
+        x = um.spsolve(a, b)
+        assert_allclose(a @ x, self.b)
+
+    def test_splu_solve(self):
+        # Prefactorize (with UMFPACK) matrix for solving with multiple rhs
+        a = self.a.astype('d')
+        lu = um.splu(a)
+
+        x1 = lu.solve(self.b)
+        assert_allclose(a @ x1, self.b)
+        x2 = lu.solve(self.b2)
+        assert_allclose(a @ x2, self.b2)
+
+    @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
+    def test_splu_solve_int64(self):
+        # Prefactorize (with UMFPACK) matrix with int64 indices for solving with
+        # multiple rhs
+        a = _to_int64(self.a.astype('d'), array=True)
+        lu = um.splu(a)
+
+        x1 = lu.solve(self.b)
+        assert_allclose(a @ x1, self.b)
+        x2 = lu.solve(self.b2)
+        assert_allclose(a @ x2, self.b2)
+
+    def test_splu_solve_sparse(self):
+        # Prefactorize (with UMFPACK) matrix for solving with multiple rhs
+        A = self.a.astype('d')
+        lu = um.splu(A)
+
+        b = csc_array(self.b.reshape(self.b.shape[0], 1))
+        b2 = csc_array(self.b2.reshape(self.b2.shape[0], 1))
+        B = hstack((b, b2))
+
+        X = lu.solve_sparse(B)
+        assert dense_norm(((A @ X) - B).todense()) < 1e-14
+        assert_allclose((A @ X).todense(), B.todense())
+
+    def test_splu_lu(self):
+        A = csc_array([[1,2,0,4],[1,0,0,1],[1,0,2,1],[2,2,1,0.]])
+
+        lu = um.splu(A)
+
+        Pr = np.zeros((4, 4))
+        Pr[lu.perm_r, np.arange(4)] = 1
+        Pr = csc_array(Pr)
+        Pc = np.zeros((4, 4))
+        Pc[np.arange(4), lu.perm_c] = 1
+        Pc = csc_array(Pc)
+
+        R = csc_array((4, 4))
+        R.setdiag(lu.R)
+
+        A2 = (R @ Pr.T @ (lu.L @ lu.U) @ Pc.T).A
 
         assert_allclose(A2, A.A, atol=1e-13)
 

--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -136,10 +136,9 @@ class TestSolvers(unittest.TestCase):
         assert_allclose(A2, A.A, atol=1e-13)
 
 class TestSolversWithArrays(unittest.TestCase):
-    """Same tests as above, but using the csc_array interface. 
-    
-    Key difference is that sparse arrays support matrix multiplication with
-    the @ operator rather than the * operator.
+    """Same tests as above, but using the csc_array interface. Key difference 
+    is that sparse arrays support matrix multiplication with the @ operator
+    rather than the * operator.
     """
 
     def setUp(self):

--- a/scikits/umfpack/umfpack.py
+++ b/scikits/umfpack/umfpack.py
@@ -472,10 +472,12 @@ class UmfpackContext(Struct):
     # 01.03.2006
     def _getIndx(self, mtx):
 
-        if sp.isspmatrix_csc(mtx) or (hasattr(sp, 'csc_array') and isinstance(mtx, sp.csc_array)):
+        if (sp.isspmatrix_csc(mtx) or 
+            (hasattr(sp, 'csc_array') and isinstance(mtx, sp.csc_array))):
             indx = mtx.indices
             self.isCSR = 0
-        elif sp.isspmatrix_csr(mtx) or (hasattr(sp, 'csr_array') and isinstance(mtx, sp.csr_array)):
+        elif (sp.isspmatrix_csr(mtx) or 
+              (hasattr(sp, 'csr_array') and isinstance(mtx, sp.csr_array))):
             indx = mtx.indices
             self.isCSR = 1
         else:

--- a/scikits/umfpack/umfpack.py
+++ b/scikits/umfpack/umfpack.py
@@ -472,10 +472,10 @@ class UmfpackContext(Struct):
     # 01.03.2006
     def _getIndx(self, mtx):
 
-        if sp.isspmatrix_csc(mtx):
+        if sp.isspmatrix_csc(mtx) or (hasattr(sp, 'csc_array') and isinstance(mtx, sp.csc_array)):
             indx = mtx.indices
             self.isCSR = 0
-        elif sp.isspmatrix_csr(mtx):
+        elif sp.isspmatrix_csr(mtx) or (hasattr(sp, 'csr_array') and isinstance(mtx, sp.csr_array)):
             indx = mtx.indices
             self.isCSR = 1
         else:


### PR DESCRIPTION
By checking if scipy.sparse defines csc_array before the isinstance check, this doesn't have to be a breaking change. Fixes #99 

Borrowed the implementation strategy in scikit-sparse here: https://github.com/scikit-sparse/scikit-sparse/pull/102/files