### PR TITLE
add homebrew installed suitesparse include path

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,8 @@ _try_incdirs = [
     '/opt/local/include/ufsparse',
     '/opt/local/include',
     '/sw/include',
-    '/usr/include/suitesparse'
+    '/usr/include/suitesparse',
+    '/opt/homebrew/include/suitesparse'
 ]
 suitesparse_incdirs = []
 umfpack_header_dirs = []


### PR DESCRIPTION
this PR makes it build on macOS when `brew install suite-sparse` was used to install the needed dependency.

Otherwise it fails with the same error mentioned here https://github.com/scikit-umfpack/scikit-umfpack/issues/96#issuecomment-1828174957 