### PR TITLE
Replace old macros

### DIFF
--- a/scikits/umfpack/umfpack.i
+++ b/scikits/umfpack/umfpack.i
@@ -116,7 +116,7 @@ PyArrayObject *helper_getCArrayObject( PyObject *input, int type,
 #define ARRAY_IN( rtype, ctype, atype ) \
 %typemap( in ) (ctype *array) { \
   PyArrayObject *obj; \
-  obj = helper_getCArrayObject( $input, PyArray_##atype, 1, 1 ); \
+  obj = helper_getCArrayObject( $input, NPY_##atype, 1, 1 ); \
   if (!obj) return NULL; \
   $1 = (rtype *) obj->data; \
   Py_DECREF( obj ); \
@@ -129,7 +129,7 @@ PyArrayObject *helper_getCArrayObject( PyObject *input, int type,
 #define CONF_IN( arSize ) \
 %typemap( in ) (double conf [arSize]) { \
   PyArrayObject *obj; \
-  obj = helper_getCArrayObject( $input, PyArray_DOUBLE, 1, 1 ); \
+  obj = helper_getCArrayObject( $input, NPY_DOUBLE, 1, 1 ); \
   if (!obj) return NULL; \
   if ((obj->nd != 1) || (obj->dimensions[0] != arSize)) { \
     PyErr_SetString( PyExc_ValueError, "wrong Control/Info array size" ); \


### PR DESCRIPTION
This PR fixes the compilation issue described in https://github.com/scikit-umfpack/scikit-umfpack/issues/101.

Without this fix, compilation because the `PyArray_CONSTANT` macros have been removed from NumPy (https://numpy.org/doc/stable/release/2.0.0-notes.html#numpy-2-0-c-api-removals). 

```
      FAILED: scikits/umfpack/__umfpack.cpython-312-x86_64-linux-gnu.so.p/meson-generated_..__umfpack_wrap.c.o
      cc -Iscikits/umfpack/__umfpack.cpython-312-x86_64-linux-gnu.so.p -Iscikits/umfpack -I../scikits/umfpack -I../../../pip-build-env-8pjxawof/overlay/lib/python3.12/site-packages/numpy/_core/include -I/usr/include/suitesparse -I/usr/local/include -I/home/jeff/.pyenv/versions/3.12.3/include/python3.12 -fvisibility=hidden -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c99 -O3 -fPIC -Wno-misleading-indentation -Wno-incompatible-pointer-types -MD -MQ scikits/umfpack/__umfpack.cpython-312-x86_64-linux-gnu.so.p/meson-generated_..__umfpack_wrap.c.o -MF scikits/umfpack/__umfpack.cpython-312-x86_64-linux-gnu.so.p/meson-generated_..__umfpack_wrap.c.o.d -o scikits/umfpack/__umfpack.cpython-312-x86_64-linux-gnu.so.p/meson-generated_..__umfpack_wrap.c.o -c scikits/umfpack/_umfpack_wrap.c
      In file included from ../../../pip-build-env-8pjxawof/overlay/lib/python3.12/site-packages/numpy/_core/include/numpy/ndarraytypes.h:1909,
                       from ../../../pip-build-env-8pjxawof/overlay/lib/python3.12/site-packages/numpy/_core/include/numpy/ndarrayobject.h:12,
                       from ../../../pip-build-env-8pjxawof/overlay/lib/python3.12/site-packages/numpy/_core/include/numpy/arrayobject.h:5,
                       from scikits/umfpack/_umfpack_wrap.c:2675:
      ../../../pip-build-env-8pjxawof/overlay/lib/python3.12/site-packages/numpy/_core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
         17 | #warning "Using deprecated NumPy API, disable it with " \
            |  ^~~~~~~
      scikits/umfpack/_umfpack_wrap.c: In function ‘_wrap_umfpack_di_solve’:
      scikits/umfpack/_umfpack_wrap.c:2977:71: error: ‘PyArray_INT’ undeclared (first use in this function); did you mean ‘PyArray_API’?
       2977 |     PyArrayObject *obj;    obj = helper_getCArrayObject( swig_obj[1], PyArray_INT, 1, 1 );    if (!obj) return NULL;    arg2 = (int *) obj->data;    Py_DECREF( obj );
            |                                                                       ^~~~~~~~~~~
            |                                                                       PyArray_API
      scikits/umfpack/_umfpack_wrap.c:2977:71: note: each undeclared identifier is reported only once for each function it appears in
      scikits/umfpack/_umfpack_wrap.c:2983:71: error: ‘PyArray_DOUBLE’ undeclared (first use in this function); did you mean ‘PyArray_DTYPE’?
       2983 |     PyArrayObject *obj;    obj = helper_getCArrayObject( swig_obj[3], PyArray_DOUBLE, 1, 1 );    if (!obj) return NULL;    arg4 = (double *) obj->data;    Py_DECREF( obj );
            |                                                                       ^~~~~~~~~~~~~~
            |                                                                       PyArray_DTYPE
```

I replaced these macros with the corresponding ones from https://github.com/numpy/numpy/blob/main/tools/replace_old_macros.sed, and the package now compiles and works.