### PR TITLE
UMFPACK single header/stdint support

### DIFF
--- a/scikits/umfpack/umfpack.i
+++ b/scikits/umfpack/umfpack.i
@@ -9,6 +9,8 @@
   Created by: Robert Cimrman
 */
 
+%include <stdint.i>
+
 %{
 #include <umfpack.h>
 #include "numpy/arrayobject.h"
@@ -16,25 +18,6 @@
 
 
 %feature("autodoc", "1");
-
-%{
-#ifndef SuiteSparse_long
-    #define SuiteSparse_long UF_long
-#endif
-%}
-
-typedef int64_t SuiteSparse_long;
-typedef SuiteSparse_long UF_long;
-
-/* Convert from Python --> C */
-%typemap(in) SuiteSparse_long {
-  $1 = (SuiteSparse_long)PyInt_AsLong($input);
-}
-
-/* Convert from C --> Python */
-%typemap(out) SuiteSparse_long {
-  $result = PyInt_FromLong((int)$1);
-}
 
 %init %{
     import_array();
@@ -169,22 +152,16 @@ PyArrayObject *helper_getCArrayObject( PyObject *input, int type,
   $result = helper_appendToTuple( $result, obj ); \
 };
 
-ARRAY_IN( int, const int, INT )
-%apply const int *array {
-    const int Ap [ ],
-    const int Ai [ ]
+ARRAY_IN( int32_t, const int32_t, INT32 )
+%apply const int32_t *array {
+    const int32_t Ap [ ],
+    const int32_t Ai [ ]
 };
 
-ARRAY_IN( long, const long, LONG )
-%apply const long *array {
-    const long Ap [ ],
-    const long Ai [ ]
-};
-
-ARRAY_IN( SuiteSparse_long, const SuiteSparse_long, INT64 )
-%apply const SuiteSparse_long *array {
-    const SuiteSparse_long Ap [ ],
-    const SuiteSparse_long Ai [ ]
+ARRAY_IN( int64_t, const int64_t, INT64 )
+%apply const int64_t *array {
+    const int64_t Ap [ ],
+    const int64_t Ai [ ]
 };
 
 ARRAY_IN( double, const double, DOUBLE )
@@ -225,12 +202,12 @@ OPAQUE_ARGOUT( void * )
  * wnbell - attempt to get L,U,P,Q out
  */
 %include "typemaps.i"
-%apply int  *OUTPUT {
-    int *lnz,
-    int *unz,
-    int *n_row,
-    int *n_col,
-    int *nz_udiag
+%apply long  *OUTPUT {
+    int32_t *lnz,
+    int32_t *unz,
+    int32_t *n_row,
+    int32_t *n_col,
+    int32_t *nz_udiag
 };
 %apply long *OUTPUT {
     long *lnz,
@@ -239,12 +216,12 @@ OPAQUE_ARGOUT( void * )
     long *n_col,
     long *nz_udiag
 };
-%apply long *OUTPUT {
-    SuiteSparse_long *lnz,
-    SuiteSparse_long *unz,
-    SuiteSparse_long *n_row,
-    SuiteSparse_long *n_col,
-    SuiteSparse_long *nz_udiag
+%apply int *OUTPUT {
+    int64_t *lnz,
+    int64_t *unz,
+    int64_t *n_row,
+    int64_t *n_col,
+    int64_t *nz_udiag
 };
 
 
@@ -259,38 +236,27 @@ ARRAY_IN( double, double, DOUBLE )
     double Rs [ ]
 };
 
-ARRAY_IN( int, int, INT )
-%apply int *array {
-    int Lp [ ],
-    int Lj [ ],
-    int Up [ ],
-    int Ui [ ],
-    int P [ ],
-    int Q [ ]
+ARRAY_IN( int32_t, int32_t, INT32 )
+%apply int32_t *array {
+    int32_t Lp [ ],
+    int32_t Lj [ ],
+    int32_t Up [ ],
+    int32_t Ui [ ],
+    int32_t P [ ],
+    int32_t Q [ ]
 };
-%apply int  *OUTPUT { int *do_recip};
+%apply int32_t  *OUTPUT { int32_t *do_recip};
 
-ARRAY_IN( long, long, LONG )
-%apply long *array {
-    long Lp [ ],
-    long Lj [ ],
-    long Up [ ],
-    long Ui [ ],
-    long P [ ],
-    long Q [ ]
+ARRAY_IN( int64_t, int64_t, INT64 )
+%apply int64_t *array {
+    int64_t Lp [ ],
+    int64_t Lj [ ],
+    int64_t Up [ ],
+    int64_t Ui [ ],
+    int64_t P [ ],
+    int64_t Q [ ]
 };
-%apply long *OUTPUT { long *do_recip};
-
-ARRAY_IN( SuiteSparse_long, SuiteSparse_long, INT64 )
-%apply SuiteSparse_long *array {
-    SuiteSparse_long Lp [ ],
-    SuiteSparse_long Lj [ ],
-    SuiteSparse_long Up [ ],
-    SuiteSparse_long Ui [ ],
-    SuiteSparse_long P [ ],
-    SuiteSparse_long Q [ ]
-};
-%apply long *OUTPUT { SuiteSparse_long *do_recip};
+%apply int64_t *OUTPUT { int64_t *do_recip};
 
 /* The *_free_* functions are the only ones where arguments void **Symbolic and
 void **Numeric are not outputs. Ignore these when importing the file then


### PR DESCRIPTION
Based on @josephlr's work on #106, but with support for the `umfpack_*_free_symbolic` and `umfpack_*_free_numeric` functions.

It differs in that <stdint.i> is included in order for SWIG's builtin typemaps to work on the integer types, allowing the SuiteSparse_long ones to be removed.

It does not include @josephlr / @JohnD90's changes to `umfpack.py` which check the datatype of array indices.

Non-skipped tests pass with suitesparse > 7 on 
- Windows (anaconda, Python 3.12, numpy 1.26.4 or 2.1.3 if allowed in pyproject.toml) 
- Windows (anaconda, Python 3.13, numpy 1.26.4 or 2.1.3)
- Ubuntu (using WSL) (Python 3.12, numpy 1.26.4 or 2.2.4)

This will most likely break compatibility with versions of suitesparse with separate headers