### PR TITLE
Fix UmfpackLU permutations

### DIFF
--- a/scikits/umfpack/interface.py
+++ b/scikits/umfpack/interface.py
@@ -172,7 +172,7 @@ class UmfpackLU(object):
 
     We can reassemble the original matrix:
 
-    >>> (Pr.T * R * (lu.L * lu.U) * Pc.T).A
+    >>> (R * Pr.T * (lu.L * lu.U) * Pc.T).A
     array([[ 1.,  2.,  0.,  4.],
            [ 1.,  0.,  0.,  1.],
            [ 1.,  0.,  2.,  1.],

--- a/scikits/umfpack/interface.py
+++ b/scikits/umfpack/interface.py
@@ -276,7 +276,8 @@ class UmfpackLU(object):
                     np.reciprocal(self._R, out=self._R)
 
             # Conform to scipy.sparse.splu convention on permutation matrices
-            self._P = self._P[self._P]
+            self._P = np.argsort(self._P)
+            self._Q = np.argsort(self._Q)
 
     @property
     def shape(self):

--- a/scikits/umfpack/interface.py
+++ b/scikits/umfpack/interface.py
@@ -147,12 +147,12 @@ class UmfpackLU(object):
 
     The L and U factors are sparse matrices in CSC format:
 
-    >>> lu.L.A
+    >>> lu.L.toarray()
     array([[ 1. ,  0. ,  0. ,  0. ],
            [ 0. ,  1. ,  0. ,  0. ],
            [ 0. ,  0. ,  1. ,  0. ],
            [ 1. ,  0.5,  0.5,  1. ]])
-    >>> lu.U.A
+    >>> lu.U.toarray()
     array([[ 2.,  0.,  1.,  4.],
            [ 0.,  2.,  1.,  1.],
            [ 0.,  0.,  1.,  1.],
@@ -172,11 +172,19 @@ class UmfpackLU(object):
 
     We can reassemble the original matrix:
 
-    >>> (R * Pr.T * (lu.L * lu.U) * Pc.T).A
+    >>> (R * Pr.T * (lu.L * lu.U) * Pc.T).toarray()
     array([[ 1.,  2.,  0.,  4.],
            [ 1.,  0.,  0.,  1.],
            [ 1.,  0.,  2.,  1.],
            [ 2.,  2.,  1.,  0.]])
+
+    Note
+    ----
+    The permutation vectors ``perm_r`` and ``perm_c`` are the inverses of 
+    permutation vectors ``P`` and ``Q`` returned by lower-level 
+    ``UmfpackContext.lu()``. This is so that matrices Pr and Pc are 
+    reconstructed as shown above, for consistency with 
+    ``scipy.sparse.linalg.splu``.
     """
 
     def __init__(self, A):

--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -119,7 +119,7 @@ class TestSolvers(unittest.TestCase):
         assert_allclose((A*X).todense(), B.todense())
 
     def test_splu_lu(self):
-        A = csc_matrix([[1,2,0,4],[1,0,0,1],[1,0,2,1],[2,2,1,0.]])
+        A = csc_matrix([[1,2,0,4],[1,0,3,1],[1,0,2,1],[2,2,1,0.]])
 
         lu = um.splu(A)
 
@@ -233,7 +233,7 @@ class TestSolversWithArrays(unittest.TestCase):
         assert_allclose((A @ X).todense(), B.todense())
 
     def test_splu_lu(self):
-        A = csc_array([[1,2,0,4],[1,0,0,1],[1,0,2,1],[2,2,1,0.]])
+        A = csc_array([[1,2,0,4],[1,0,3,1],[1,0,2,1],[2,2,1,0.]])
 
         lu = um.splu(A)
 


### PR DESCRIPTION
As described in #60: when using the UmfpackLU interface, the original matrix could often not be reconstructed by R Pr<sup>T</sup> L U Pc<sup>T</sup>.

See the [comment on that issue](https://github.com/scikit-umfpack/scikit-umfpack/issues/60#issuecomment-2910540415) for details, but in summary, it looks like:
- UmfpackLU inverts the permutation vectors output by the lower level `UmfpackContext.lu` so that they follow the same convention for matrix reconstruction as the permutation vectors for SuperLU in `scipy.sparse.linalg.splu`
- The code for doing this was wrong, and was applied only to the column permutation.
- If the original permutations had certain properties, the incorrect method would still give correct inverse permutations, meaning that some matrices could be reconstructed correctly, while others couldn’t.
- The permutations for the matrix in the test case had these properties, meaning that the test passed despite the error.

This PR correctly inverts both permutations so that reconstruction works for general matrices. [This gist](https://gist.github.com/AndyJenks/e5f494c10d8dad785fb2cbc4a2b222c1) demonstrates the problem without the changes and works correctly with the changes applied.