### PR TITLE
get swig includes from umfpack dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,11 @@ project(
 fs = import('fs')
 py = import('python').find_installation(pure: false)
 
+# wrapper around swig to extract includes from umfpack dependency
+# future version of meson should fix this:
+# https://github.com/mesonbuild/meson/issues/8334
+meson_swig = fs.copyfile('meson_swig.py')
+
 cc = meson.get_compiler('c')
 
 swig = find_program('swig', required: true, native: true)
@@ -68,6 +73,7 @@ if not umfpack_dep.found()
       has_headers : ['umfpack.h']
   )
   umfpack_dep = declare_dependency(
+    name: 'UMFPACK',
     dependencies: umfpack_lib,
     include_directories: umfpack_header_dirs,
   )

--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,6 @@ if not umfpack_dep.found()
       has_headers : ['umfpack.h']
   )
   umfpack_dep = declare_dependency(
-    name: 'UMFPACK',
     dependencies: umfpack_lib,
     include_directories: umfpack_header_dirs,
   )

--- a/meson_swig.py
+++ b/meson_swig.py
@@ -16,13 +16,16 @@ meson_info = Path("meson-info")
 with (meson_info / "intro-dependencies.json").open() as f:
     dependency_list = json.load(f)
 
-# cast to a dict
-dependencies = {dep["name"].lower(): dep for dep in dependency_list}
+# dict by dependency variable(s) name
+dependencies = {}
+for dep in dependency_list:
+    for name in dep["meson_variables"]:
+        dependencies[name] = dep
 
 # get umfpack dependency
-umfpack = dependencies.get("umfpack")
-if "umfpack" not in dependencies:
-    sys.exit(f"umfpack not found in dependencies: {', '.join(dependencies)}")
+umfpack = dependencies.get("umfpack_dep")
+if umfpack is None:
+    sys.exit(f"umfpack_dep not found in dependencies: {', '.join(dependencies)}")
 
 # load include directories from meson dep
 includes = []

--- a/meson_swig.py
+++ b/meson_swig.py
@@ -1,0 +1,42 @@
+"""
+workaround https://github.com/mesonbuild/meson/issues/8334
+
+by getting dependency info from meson-info.
+When dependency.as_dict() is added, can use that instead.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+# load dependency list
+meson_info = Path("meson-info")
+with (meson_info / "intro-dependencies.json").open() as f:
+    dependency_list = json.load(f)
+
+# cast to a dict
+dependencies = {dep["name"].lower(): dep for dep in dependency_list}
+
+# get umfpack dependency
+umfpack = dependencies.get("umfpack")
+if "umfpack" not in dependencies:
+    sys.exit(f"umfpack not found in dependencies: {', '.join(dependencies)}")
+
+# load include directories from meson dep
+includes = []
+for include_dir in umfpack["include_directories"]:
+    includes.append(f"-I{include_dir}")
+# pkg-config puts includes in compile_args
+for arg in umfpack["compile_args"]:
+    # could this look different on Windows?
+    if arg.startswith("-I"):
+        includes.append(arg)
+
+swig = sys.argv[1]
+swig_argv = sys.argv[1:]
+# insert includes after '-python'
+swig_argv[2:2] = includes
+# actually launch swig
+os.execv(swig, swig_argv)

--- a/scikits/umfpack/meson.build
+++ b/scikits/umfpack/meson.build
@@ -9,11 +9,9 @@ except Exception:
 print(incdir)
 '''], check: true).stdout().strip()
 
-# SWIG needs to find umfpack.h, so add all potential candidates
+# swig include is extracted from the umfpack dependency
+# in meson_swig.py
 swig_inc_args = []
-foreach _dir : suitesparse_incdirs
-    swig_inc_args += '-I' + _dir
-endforeach
 
 # This is a hack that gets at the location for conda envs (and perhaps other
 # types of envs), when building with conda compilers. We need proper SWIG
@@ -47,13 +45,14 @@ elif cc.get_id() == 'clang'
 endif
 # The above took care of all fixed directories. We also need the default
 # compiler search directories, but Meson doesn't expose those.
+
 _umfpack_swig = custom_target('_umfpack_swig',
     output: [
         '_umfpack_wrap.c',
         '_umfpack.py',
     ],
     input: 'umfpack.i',
-    command: [swig, '-python'] + swig_defines + swig_inc_args + [
+    command: [py, meson_swig, swig, '-python'] + swig_defines + swig_inc_args + [
               '-o', '@OUTPUT0@', '-outdir', '@OUTDIR@', '@INPUT@'],
     install: true,
     install_dir: py.get_install_dir() / 'scikits/umfpack',  # need to install _umfpack.py


### PR DESCRIPTION
adds meson_swig.py wrapper to extract include flags from dependency file. Workaround for https://github.com/mesonbuild/meson/issues/8334 .

I noticed this testing the latest changes with the conda-forge recipe.

While meson finds umfpack with pkg-config, the found location is not added to the swig include directories, leading to

```
../scikits/umfpack/umfpack.i:381: Error: Unable to find 'umfpack.h'
```

I tried to follow the advice in workaround for https://github.com/mesonbuild/meson/issues/8334 to get the include args out of `meson-info/intro-dependencies.json`. I don't know what, if anything, needs to change for Windows.