### PR TITLE
Sparse array support

### DIFF
--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_allclose
 from numpy.linalg import norm as dense_norm
 
 import scipy
-from scipy.sparse import csc_array, csc_matrix, spdiags, SparseEfficiencyWarning
+from scipy.sparse import csc_array, csc_matrix, coo_array, spdiags, SparseEfficiencyWarning
 from scipy.sparse import hstack
 
 import numpy as np
@@ -191,7 +191,15 @@ class TestSolversWithArrays(unittest.TestCase):
     def test_solve_sparse_rhs(self):
         # Solve with UMFPACK: double precision, sparse rhs
         a = self.a.astype('d')
-        b = csc_array(self.b).T
+        b = csc_array(self.b.reshape(self.b.shape[0], 1))
+        # b = scipy.sparse.coo_array(self.b)
+        x = um.spsolve(a, b)
+        assert_allclose(a @ x, self.b)
+
+    @unittest.skipIf(Version(scipy.__version__) < Version("1.13"), "Scipy <1.13 does not support 1D sparse arrays")
+    def test_solve_1D_sparse_rhs(self):
+        a = self.a.astype('d')
+        b = coo_array(self.b)
         x = um.spsolve(a, b)
         assert_allclose(a @ x, self.b)
 

--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -138,7 +138,6 @@ class TestSolvers(unittest.TestCase):
         assert_allclose(A2, A.toarray(), atol=1e-13)
 
 
-@unittest.skipIf(Version(scipy.__version__) >= Version("1.13"), "Needs to fix deprecation")
 class TestSolversWithArrays(unittest.TestCase):
     """Same tests as above, but using the csc_array interface. Key difference 
     is that sparse arrays support matrix multiplication with the @ operator
@@ -189,7 +188,6 @@ class TestSolversWithArrays(unittest.TestCase):
         x = um.spsolve(a, b)
         assert_allclose(a @ x, b)
 
-    @unittest.skipIf(Version(scipy.__version__) >= Version("1.14"), "Needs to fix deprecation")
     def test_solve_sparse_rhs(self):
         # Solve with UMFPACK: double precision, sparse rhs
         a = self.a.astype('d')

--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -153,6 +153,13 @@ class TestSolversWithArrays(unittest.TestCase):
         self.mgr.__enter__()
 
         warnings.simplefilter('ignore', SparseEfficiencyWarning)
+        warnings.filterwarnings(
+            'ignore',
+            category=DeprecationWarning,
+            message=(
+                "From scikit-umfpack 0.5.0 onwards, UmfpackContext.lu will "
+                "return L & U as sparse arrays when called with an array.")
+            )
 
     def tearDown(self):
         self.mgr.__exit__()

--- a/scikits/umfpack/tests/test_interface.py
+++ b/scikits/umfpack/tests/test_interface.py
@@ -235,7 +235,7 @@ class TestSolversWithArrays(unittest.TestCase):
         B = hstack((b, b2))
 
         X = lu.solve_sparse(B)
-        assert dense_norm(((A @ X) - B).todense()) < 1e-14
+        assert dense_norm(((A @ X) - B).todense()) < 2e-14
         assert_allclose((A @ X).todense(), B.todense())
 
     def test_splu_lu(self):

--- a/scikits/umfpack/tests/test_umfpack.py
+++ b/scikits/umfpack/tests/test_umfpack.py
@@ -131,9 +131,9 @@ class TestFactorization(_DeprecationAccept):
 
     def test_complex_lu(self):
         # Getting factors of complex matrix
-        umfpack = um.UmfpackContext("zi")
 
         for A in self.complex_matrices:
+            umfpack = um.UmfpackContext("zi")
             umfpack.numeric(A)
 
             (L,U,P,Q,R,do_recip) = umfpack.lu(A)
@@ -152,9 +152,9 @@ class TestFactorization(_DeprecationAccept):
     @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_complex_int64_lu(self):
         # Getting factors of complex matrix with long indices
-        umfpack = um.UmfpackContext("zl")
 
         for A in self.complex_int64_matrices:
+            umfpack = um.UmfpackContext("zl")
             umfpack.numeric(A)
 
             (L,U,P,Q,R,do_recip) = umfpack.lu(A)
@@ -172,9 +172,9 @@ class TestFactorization(_DeprecationAccept):
 
     def test_real_lu(self):
         # Getting factors of real matrix
-        umfpack = um.UmfpackContext("di")
 
         for A in self.real_matrices:
+            umfpack = um.UmfpackContext("di")
             umfpack.numeric(A)
 
             (L,U,P,Q,R,do_recip) = umfpack.lu(A)
@@ -193,9 +193,9 @@ class TestFactorization(_DeprecationAccept):
     @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_real_int64_lu(self):
         # Getting factors of real matrix with long indices
-        umfpack = um.UmfpackContext("dl")
 
         for A in self.real_int64_matrices:
+            umfpack = um.UmfpackContext("dl")
             umfpack.numeric(A)
 
             (L,U,P,Q,R,do_recip) = umfpack.lu(A)

--- a/scikits/umfpack/tests/test_umfpack.py
+++ b/scikits/umfpack/tests/test_umfpack.py
@@ -33,6 +33,13 @@ class _DeprecationAccept(unittest.TestCase):
         self.mgr.__enter__()
 
         warnings.simplefilter('ignore', SparseEfficiencyWarning)
+        warnings.filterwarnings(
+            'ignore',
+            category=DeprecationWarning,
+            message=(
+                "From scikit-umfpack 0.5.0 onwards, UmfpackContext.lu will "
+                "return L & U as sparse arrays when called with an array.")
+            )
 
     def tearDown(self):
         self.mgr.__exit__()

--- a/scikits/umfpack/tests/test_umfpack.py
+++ b/scikits/umfpack/tests/test_umfpack.py
@@ -143,11 +143,11 @@ class TestFactorization(_DeprecationAccept):
             A = A.todense()
             if not do_recip:
                 R = 1.0/R
-            R = np.matrix(np.diag(R))
+            R = np.diag(R)
             P = np.eye(A.shape[0])[P,:]
             Q = np.eye(A.shape[1])[:,Q]
 
-            assert_array_almost_equal(P*R*A*Q,L*U)
+            assert_array_almost_equal(P @ R @ A @ Q, L @ U)
 
     @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_complex_int64_lu(self):
@@ -164,11 +164,11 @@ class TestFactorization(_DeprecationAccept):
             A = A.todense()
             if not do_recip:
                 R = 1.0/R
-            R = np.matrix(np.diag(R))
+            R = np.diag(R)
             P = np.eye(A.shape[0])[P,:]
             Q = np.eye(A.shape[1])[:,Q]
 
-            assert_array_almost_equal(P*R*A*Q,L*U)
+            assert_array_almost_equal(P @ R @ A @ Q, L @ U)
 
     def test_real_lu(self):
         # Getting factors of real matrix
@@ -184,11 +184,11 @@ class TestFactorization(_DeprecationAccept):
             A = A.todense()
             if not do_recip:
                 R = 1.0/R
-            R = np.matrix(np.diag(R))
+            R = np.diag(R)
             P = np.eye(A.shape[0])[P,:]
             Q = np.eye(A.shape[1])[:,Q]
 
-            assert_array_almost_equal(P*R*A*Q,L*U)
+            assert_array_almost_equal(P @ R @ A @ Q, L @ U)
 
     @unittest.skipIf(_is_32bit_platform, reason="requires 64 bit platform")
     def test_real_int64_lu(self):
@@ -205,11 +205,11 @@ class TestFactorization(_DeprecationAccept):
             A = A.todense()
             if not do_recip:
                 R = 1.0/R
-            R = np.matrix(np.diag(R))
+            R = np.diag(R)
             P = np.eye(A.shape[0])[P,:]
             Q = np.eye(A.shape[1])[:,Q]
 
-            assert_array_almost_equal(P*R*A*Q,L*U)
+            assert_array_almost_equal(P @ R @ A @ Q, L @ U)
 
     def setUp(self):
         random.seed(0)  # make tests repeatable

--- a/scikits/umfpack/umfpack.py
+++ b/scikits/umfpack/umfpack.py
@@ -845,6 +845,13 @@ class UmfpackContext(Struct):
 
         """
 
+        if sp.issparse(mtx) and not sp.isspmatrix(mtx):
+            warnings.warn((
+                "From scikit-umfpack 0.5.0 onwards, UmfpackContext.lu will "
+                "return L & U as sparse arrays when called with an array."),
+                DeprecationWarning,
+                stacklevel=2)
+
         # this should probably be changed
         mtx = mtx.tocsc()
         self.numeric(mtx)


### PR DESCRIPTION
The scipy sparse matrix is on the way out, and is being replaced with the sparse array much like the numpy matrix was replaced with the array.

With very recent versions of numpy, the test suite gives rise to a number of PendingDeprecationWarnings for matrices:
```
PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
```

This PR reintroduces the array tests in `test_interface`, adds array tests in `test_umfpack`, and makes a few changes so that array input gives array output in most of the high-level interface.

The only remaining problem I am aware of is the lower-level LU function in `umfpack.py`, which returns L and U as sparse matrix objects. The same objects are returned by the higher level UmfpackLU interface. It would be trivially easy to change these to sparse array objects, but given that using arrays rather than matrices requires user code to be changed and may (if square matrices are being multiplied) lead to silent errors, it may not be OK to change it in one go.